### PR TITLE
Databases: Create Seeding for Products and Categories Table Separately

### DIFF
--- a/src/server/seeds/development/01_categories.js
+++ b/src/server/seeds/development/01_categories.js
@@ -1,0 +1,28 @@
+exports.seed = function (knex) {
+  return knex('categories')
+    .del()
+    .then(function () {
+      return knex('categories').insert([
+        {
+          id: 1,
+          name: 'Furniture',
+          created_at: '2020-05-11 00:00:00',
+        },
+        {
+          id: 2,
+          name: 'Lamps',
+          created_at: '2020-05-11 00:00:00',
+        },
+        {
+          id: 3,
+          name: 'Home decor',
+          created_at: '2020-05-11 00:00:00',
+        },
+        {
+          id: 4,
+          name: 'Linens',
+          created_at: '2020-05-11 00:00:00',
+        },
+      ]);
+    });
+};

--- a/src/server/seeds/development/02_products.js
+++ b/src/server/seeds/development/02_products.js
@@ -1,98 +1,99 @@
 exports.seed = function (knex) {
-  return knex('products')
-    .del()
-    .then(function () {
-      return knex('products').insert([
-        {
-          name: 'Ceramic pot',
-          price: 50,
-          picture: 'src/client/assets/images/image01.png',
-          stock_amount: 20,
-          category_id: 3,
-        },
-        {
-          name: 'Table lamp',
-          price: 150,
-          color: 'white',
-          picture: 'src/client/assets/images/image02.png',
-          stock_amount: 58,
-          category_id: 2,
-        },
-        {
-          name: 'Ceramic pottery',
-          price: 120,
-          color: 'blue',
-          picture: 'src/client/assets/images/image03.png',
-          stock_amount: 140,
-          category_id: 3,
-        },
-        {
-          name: 'Picture frame',
-          price: 80,
-          color: 'white',
-          picture: 'src/client/assets/images/image04.png',
-          stock_amount: 2,
-          category_id: 3,
-        },
-        {
-          name: 'Pillow case',
-          price: 65,
-          color: 'white',
-          picture: 'src/client/assets/images/image05.png',
-          stock_amount: 2,
-          category_id: 4,
-        },
-        {
-          name: 'Knitted plaid',
-          price: 80,
-          picture: 'src/client/assets/images/image06.png',
-          stock_amount: 134,
-          category_id: 4,
-        },
-        {
-          name: 'Mirror diamonds',
-          price: 520,
-          picture: 'src/client/assets/images/image07.png',
-          stock_amount: 12,
-          category_id: 3,
-        },
-        {
-          name: 'Ceramic candliers',
-          price: 150,
-          picture: 'src/client/assets/images/image08.png',
-          stock_amount: 321,
-          category_id: 3,
-        },
-        {
-          name: 'Retro chair',
-          price: 850,
-          picture: 'src/client/assets/images/image09.png',
-          stock_amount: 7,
-          category_id: 1,
-        },
-        {
-          name: 'Modern table lamp',
-          price: 430,
-          color: 'black',
-          picture: 'src/client/assets/images/image10.png',
-          stock_amount: 12,
-          category_id: 3,
-        },
-        {
-          name: 'Silk pillow case',
-          price: 120,
-          color: 'black',
-          picture: 'src/client/assets/images/image11.png',
-          stock_amount: 12,
-          category_id: 3,
-        },
-        {
-          name: 'Modern dinig table',
-          price: 520,
-          picture: 'src/client/assets/images/image12.png',
-          stock_amount: 12,
-          category_id: 3,
-        },
-      ]);
-    });
-};
+    return knex('products')
+      .del()
+      .then(function () {
+        return knex('products').insert([
+          {
+            name: 'Ceramic pot',
+            price: 50,
+            picture: 'src/client/assets/images/image01.png',
+            stock_amount: 20,
+            category_id: 3,
+          },
+          {
+            name: 'Table lamp',
+            price: 150,
+            color: 'white',
+            picture: 'src/client/assets/images/image02.png',
+            stock_amount: 58,
+            category_id: 2,
+          },
+          {
+            name: 'Ceramic pottery',
+            price: 120,
+            color: 'blue',
+            picture: 'src/client/assets/images/image03.png',
+            stock_amount: 140,
+            category_id: 3,
+          },
+          {
+            name: 'Picture frame',
+            price: 80,
+            color: 'white',
+            picture: 'src/client/assets/images/image04.png',
+            stock_amount: 2,
+            category_id: 3,
+          },
+          {
+            name: 'Pillow case',
+            price: 65,
+            color: 'white',
+            picture: 'src/client/assets/images/image05.png',
+            stock_amount: 2,
+            category_id: 4,
+          },
+          {
+            name: 'Knitted plaid',
+            price: 80,
+            picture: 'src/client/assets/images/image06.png',
+            stock_amount: 134,
+            category_id: 4,
+          },
+          {
+            name: 'Mirror diamonds',
+            price: 520,
+            picture: 'src/client/assets/images/image07.png',
+            stock_amount: 12,
+            category_id: 3,
+          },
+          {
+            name: 'Ceramic candliers',
+            price: 150,
+            picture: 'src/client/assets/images/image08.png',
+            stock_amount: 321,
+            category_id: 3,
+          },
+          {
+            name: 'Retro chair',
+            price: 850,
+            picture: 'src/client/assets/images/image09.png',
+            stock_amount: 7,
+            category_id: 1,
+          },
+          {
+            name: 'Modern table lamp',
+            price: 430,
+            color: 'black',
+            picture: 'src/client/assets/images/image10.png',
+            stock_amount: 12,
+            category_id: 3,
+          },
+          {
+            name: 'Silk pillow case',
+            price: 120,
+            color: 'black',
+            picture: 'src/client/assets/images/image11.png',
+            stock_amount: 12,
+            category_id: 3,
+          },
+          {
+            name: 'Modern dinig table',
+            price: 520,
+            picture: 'src/client/assets/images/image12.png',
+            stock_amount: 12,
+            category_id: 3,
+          },
+        ]);
+      });
+  };
+  

--- a/src/server/seeds/development/02_products.js
+++ b/src/server/seeds/development/02_products.js
@@ -1,99 +1,98 @@
 exports.seed = function (knex) {
-    return knex('products')
-      .del()
-      .then(function () {
-        return knex('products').insert([
-          {
-            name: 'Ceramic pot',
-            price: 50,
-            picture: 'src/client/assets/images/image01.png',
-            stock_amount: 20,
-            category_id: 3,
-          },
-          {
-            name: 'Table lamp',
-            price: 150,
-            color: 'white',
-            picture: 'src/client/assets/images/image02.png',
-            stock_amount: 58,
-            category_id: 2,
-          },
-          {
-            name: 'Ceramic pottery',
-            price: 120,
-            color: 'blue',
-            picture: 'src/client/assets/images/image03.png',
-            stock_amount: 140,
-            category_id: 3,
-          },
-          {
-            name: 'Picture frame',
-            price: 80,
-            color: 'white',
-            picture: 'src/client/assets/images/image04.png',
-            stock_amount: 2,
-            category_id: 3,
-          },
-          {
-            name: 'Pillow case',
-            price: 65,
-            color: 'white',
-            picture: 'src/client/assets/images/image05.png',
-            stock_amount: 2,
-            category_id: 4,
-          },
-          {
-            name: 'Knitted plaid',
-            price: 80,
-            picture: 'src/client/assets/images/image06.png',
-            stock_amount: 134,
-            category_id: 4,
-          },
-          {
-            name: 'Mirror diamonds',
-            price: 520,
-            picture: 'src/client/assets/images/image07.png',
-            stock_amount: 12,
-            category_id: 3,
-          },
-          {
-            name: 'Ceramic candliers',
-            price: 150,
-            picture: 'src/client/assets/images/image08.png',
-            stock_amount: 321,
-            category_id: 3,
-          },
-          {
-            name: 'Retro chair',
-            price: 850,
-            picture: 'src/client/assets/images/image09.png',
-            stock_amount: 7,
-            category_id: 1,
-          },
-          {
-            name: 'Modern table lamp',
-            price: 430,
-            color: 'black',
-            picture: 'src/client/assets/images/image10.png',
-            stock_amount: 12,
-            category_id: 3,
-          },
-          {
-            name: 'Silk pillow case',
-            price: 120,
-            color: 'black',
-            picture: 'src/client/assets/images/image11.png',
-            stock_amount: 12,
-            category_id: 3,
-          },
-          {
-            name: 'Modern dinig table',
-            price: 520,
-            picture: 'src/client/assets/images/image12.png',
-            stock_amount: 12,
-            category_id: 3,
-          },
-        ]);
-      });
-  };
-  
+  return knex('products')
+    .del()
+    .then(function () {
+      return knex('products').insert([
+        {
+          name: 'Ceramic pot',
+          price: 50,
+          picture: 'src/client/assets/images/image01.png',
+          stock_amount: 20,
+          category_id: 3,
+        },
+        {
+          name: 'Table lamp',
+          price: 150,
+          color: 'white',
+          picture: 'src/client/assets/images/image02.png',
+          stock_amount: 58,
+          category_id: 2,
+        },
+        {
+          name: 'Ceramic pottery',
+          price: 120,
+          color: 'blue',
+          picture: 'src/client/assets/images/image03.png',
+          stock_amount: 140,
+          category_id: 3,
+        },
+        {
+          name: 'Picture frame',
+          price: 80,
+          color: 'white',
+          picture: 'src/client/assets/images/image04.png',
+          stock_amount: 2,
+          category_id: 3,
+        },
+        {
+          name: 'Pillow case',
+          price: 65,
+          color: 'white',
+          picture: 'src/client/assets/images/image05.png',
+          stock_amount: 2,
+          category_id: 4,
+        },
+        {
+          name: 'Knitted plaid',
+          price: 80,
+          picture: 'src/client/assets/images/image06.png',
+          stock_amount: 134,
+          category_id: 4,
+        },
+        {
+          name: 'Mirror diamonds',
+          price: 520,
+          picture: 'src/client/assets/images/image07.png',
+          stock_amount: 12,
+          category_id: 3,
+        },
+        {
+          name: 'Ceramic candliers',
+          price: 150,
+          picture: 'src/client/assets/images/image08.png',
+          stock_amount: 321,
+          category_id: 3,
+        },
+        {
+          name: 'Retro chair',
+          price: 850,
+          picture: 'src/client/assets/images/image09.png',
+          stock_amount: 7,
+          category_id: 1,
+        },
+        {
+          name: 'Modern table lamp',
+          price: 430,
+          color: 'black',
+          picture: 'src/client/assets/images/image10.png',
+          stock_amount: 12,
+          category_id: 2,
+        },
+        {
+          name: 'Silk pillow case',
+          price: 120,
+          color: 'black',
+          picture: 'src/client/assets/images/image11.png',
+          stock_amount: 12,
+          category_id: 3,
+        },
+        {
+          name: 'Modern dinig table',
+          price: 520,
+          picture: 'src/client/assets/images/image12.png',
+          stock_amount: 12,
+          category_id: 1,
+        },
+      ]);
+    });
+};

--- a/src/server/seeds/development/02_products.js
+++ b/src/server/seeds/development/02_products.js
@@ -1,33 +1,7 @@
 exports.seed = function (knex) {
-  return knex('categories')
+  return knex('products')
     .del()
-    .then(() => {
-      return knex('products').del();
-    })
-    .then(() => {
-      return knex('categories').insert([
-        {
-          id: 1,
-          name: 'Furniture',
-          created_at: '2020-05-11 00:00:00',
-        },
-        {
-          id: 2,
-          name: 'Lamps',
-          created_at: '2020-05-11 00:00:00',
-        },
-        {
-          id: 3,
-          name: 'Home decor',
-          created_at: '2020-05-11 00:00:00',
-        },
-        {
-          name: 'Linens',
-          created_at: '2020-05-11 00:00:00',
-        },
-      ]);
-    })
-    .then(() => {
+    .then(function () {
       return knex('products').insert([
         {
           name: 'Ceramic pot',


### PR DESCRIPTION
# Description

That PR is to separate both seed files so that we have the option of running each seed individually if we decide to make changes on just one of them and added 4. item an id for to get rid of identity conflict.

Fixes #50 

Databases: Create Seeding for Products and Categories Table

# How to test?

Can be tested with npm run db:setup

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [X] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [X] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [X] This PR is ready to be merged and not breaking any other functionality
