### PR TITLE
Storybook: add libary dependancy to use storybook-controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4740,6 +4740,22 @@
         "ts-dedent": "^2.0.0"
       },
       "dependencies": {
+        "@storybook/addon-controls": {
+          "version": "6.1.14",
+          "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.1.14.tgz",
+          "integrity": "sha512-4KzTD5J9pUHFe2kBE1gfDw0wjiSsXjMqX82L+l0vzt1GGqQR1Bkaqodg4eGgCM2SU50ysVWvgC3N5BYEiFeZkw==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.1.14",
+            "@storybook/api": "6.1.14",
+            "@storybook/client-api": "6.1.14",
+            "@storybook/components": "6.1.14",
+            "@storybook/node-logger": "6.1.14",
+            "@storybook/theming": "6.1.14",
+            "core-js": "^3.0.1",
+            "ts-dedent": "^2.0.0"
+          }
+        },
         "regenerator-runtime": {
           "version": "0.13.7",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.1.14",
+    "@storybook/addon-controls": "^6.1.14",
     "@storybook/addon-essentials": "^6.1.14",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",

--- a/src/client/.storybook/main.js
+++ b/src/client/.storybook/main.js
@@ -4,5 +4,6 @@ module.exports = {
     '@storybook/addon-actions',
     '@storybook/addon-knobs',
     '@storybook/addon-essentials',
+    ['@storybook/addon-controls'],
   ],
 };

--- a/src/client/.storybook/main.js
+++ b/src/client/.storybook/main.js
@@ -4,6 +4,6 @@ module.exports = {
     '@storybook/addon-actions',
     '@storybook/addon-knobs',
     '@storybook/addon-essentials',
-    ['@storybook/addon-controls'],
+    '@storybook/addon-controls',
   ],
 };


### PR DESCRIPTION
# Description

This PR will add dependancy in project, in order to use storybook controls: 
[https://storybook.js.org/addons/@storybook/addon-controls](https://storybook.js.org/addons/@storybook/addon-controls)

Instead of knobs which are now depricated
