### PR TITLE
FrontEnd: Category Page has to show Not Found Page when given category not available

### DIFF
--- a/src/client/containers/CategoryPage/CategoryPage.Container.js
+++ b/src/client/containers/CategoryPage/CategoryPage.Container.js
@@ -4,23 +4,30 @@ import ProductView from '../../components/ProductView/ProductView.component';
 import { useParams } from 'react-router-dom';
 import { useFetchApi } from '../../hooks/UseFetchApi';
 import Loader from '../../components/Loader/index';
+import Page404Container from '../404Page/404Page.Container';
 
 const CategoryPageContainer = () => {
   const { name } = useParams();
   const products = useFetchApi(`products?category=${name}`);
   return (
-    <div>
-      {products.data.isLoading ? (
-        <Loader />
+    <>
+      {products.data.length === 0 ? (
+        <Page404Container />
       ) : (
-        <ProductView
-          header={name}
-          products={products.data}
-          productsPerPage={8}
-          categoriesList={[]}
-        />
+        <div>
+          {products.data.isLoading ? (
+            <Loader />
+          ) : (
+            <ProductView
+              header={name}
+              products={products.data}
+              productsPerPage={8}
+              categoriesList={[]}
+            />
+          )}
+        </div>
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
# Description
When category is not available ..it has to show NOT FOUND Page. So that we can understand that category type where user searching is not available..
Please provide a short summary explaining what this PR is about.

Fixes # 160

# How to test?
"npm run test" and "localhost://3000/category/car"
Please provide a short summary how your changes can be tested?

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
