### PR TITLE
Move wildcard rule last

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -41,9 +41,6 @@ function App() {
         <Route exact path="/category/:name">
           <CategoryPage />
         </Route>
-        <Route path="*">
-          <Page404Container />
-        </Route>
         {/*
          * All routes below are only shown when you are not authenticated - if the
          * user is logged in, if a user is logged in, they can't see the login page
@@ -64,6 +61,10 @@ function App() {
         <AuthenticatedRoute exact path="/profile">
           <ProfilePage />
         </AuthenticatedRoute>
+        {/* Make sure to keep wildcard "*" routes in the bottom of the Switch */}
+        <Route path="*">
+          <Page404Container />
+        </Route>
       </Switch>
       <Footer />
     </Router>


### PR DESCRIPTION
# Description

Move wildcard route to bottom so it does not override any rules coming after.

# How to test?

Should fix for example /reset-password route.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [x] This PR is ready to be merged and not breaking any other functionality
