### PR TITLE
shopping component must return subTotal of shopping item based on quantity

### DIFF
--- a/src/client/components/ShoppingItem/ShoppingItem.js
+++ b/src/client/components/ShoppingItem/ShoppingItem.js
@@ -12,8 +12,13 @@ export default function ShoppingItem({
   price,
   initValue,
   isDisable,
+  getCost,
 }) {
-  const [itemValue, setItemValue] = useState(1);
+  const [itemValue, setItemValue] = useState(initValue);
+  React.useEffect(() => {
+    getCost(itemValue * price);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemValue]);
   const textColor = isDisable ? '#d3d3d3' : 'black';
   return (
     <div className="shopping-item">
@@ -47,7 +52,7 @@ export default function ShoppingItem({
         <Numberinput
           maxAvailable={quantity}
           getQuantity={setItemValue}
-          initValue={initValue}
+          initValue={itemValue}
           disabled={isDisable}
         />
         <p style={{ color: textColor }}>{itemValue * price} DKK</p>
@@ -63,9 +68,11 @@ ShoppingItem.propTypes = {
   price: PropTypes.number.isRequired,
   initValue: PropTypes.number,
   isDisable: PropTypes.bool,
+  getCost: PropTypes.func,
 };
 
 ShoppingItem.defaultProps = {
   initValue: 1,
   isDisable: false,
+  getCost: (value) => value,
 };

--- a/src/client/components/ShoppingItem/ShoppingItem.js
+++ b/src/client/components/ShoppingItem/ShoppingItem.js
@@ -52,7 +52,7 @@ export default function ShoppingItem({
         <Numberinput
           maxAvailable={quantity}
           getQuantity={setItemValue}
-          initValue={itemValue}
+          initValue={initValue}
           disabled={isDisable}
         />
         <p style={{ color: textColor }}>{itemValue * price} DKK</p>


### PR DESCRIPTION
shopping component must return subTotal of shopping item based on quantity

# Description
for shopping page to calculate the total cost of the cart, shopping item must return the cost of each item in cart based on quantity. As quantity changing control is part of shopping item.  

Fixes # (issue)


# How to test?
please run the storybook. 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [x] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [x] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [ ] This PR is ready to be merged and not breaking any other functionality
