### PR TITLE
Fixed the current bug on unit price of cart page

### DIFF
--- a/src/client/components/ShoppingItem/ShoppingItem.js
+++ b/src/client/components/ShoppingItem/ShoppingItem.js
@@ -127,7 +127,7 @@ export default function ShoppingItem({
           initValue={initValue}
           disabled={isDisable}
         />
-        <p style={{ color: textColor }}>{itemValue * price} DKK</p>
+        <p style={{ color: textColor }}>{price} DKK</p>
       </div>
     </div>
   );


### PR DESCRIPTION
# Description
Fixed the current bug of unit price on cart page. The unit price of an item was changing on changing the quantity of that item. But the unit price should be constant, it should not change on changing its quantity. So this PR fixes this bug.
# Fixes 
#285 

# How to test?
using `npm run dev` and navigate to the cart page and change the quantity of any item, the unit price remains constant

# Checklist

- [X] I have performed a self-review of my own code
- [X] I have followed the name conventions for CSS Classnames and filenames, Components names and filenames, Style filenames, if you are in doubt check the the project README.MD and here https://github.com/HackYourFuture-CPH/curriculum/blob/master/review/review-checklist.md
- [X] I have commented my code, particularly in hard-to-understand areas, if you code was simple enough mark the box anyway
- [X] I have made corresponding changes to the documentation, if you code was simple enough mark the box anyway
- [X] This PR is ready to be merged and not breaking any other functionality
